### PR TITLE
refactor/community_verification

### DIFF
--- a/demo250701/lib/main.dart
+++ b/demo250701/lib/main.dart
@@ -50,7 +50,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
       routes: {
-        '/': (context) =>  CommunityMainScreen(),//SplashScreen(), //const AuthWrapper(),
+        '/': (context) =>  SplashScreen(), //CommunityMainScreen(),
         '/login': (context) => const LoginScreen(),
         '/after-login-splash': (context) => const AfterLoginSplashScreen(),
         '/home': (context) => const HomeScreen(),

--- a/demo250701/lib/screens/community/profile_information_screen.dart
+++ b/demo250701/lib/screens/community/profile_information_screen.dart
@@ -1,8 +1,10 @@
+import 'dart:async'; // Timer를 사용하기 위해 import 합니다.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 // 필요한 서비스와 화면을 import 합니다.
 import '../../services/community_service.dart';
-import 'policy_agreement_screen.dart';
+import 'policy_agreement_screen.dart'; // 다음 화면으로 이동하기 위해 필요합니다.
 
 /// 사용자의 프로필 정보를 입력받는 화면입니다.
 /// 사용자 입력을 처리하기 위해 StatefulWidget으로 구성되었습니다.
@@ -24,35 +26,151 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
   final TextEditingController _phoneController = TextEditingController();
   final TextEditingController _authCodeController = TextEditingController();
 
+  // --- Form Key ---
+  final _formKey = GlobalKey<FormState>();
+
   // --- State Variables ---
   final List<bool> _nationalitySelection = [true, false];
   String _selectedGender = '여';
   String _selectedTelecom = 'SKT';
-  bool _isVerificationRequested = false;
   bool _isLoading = false; // 로딩 상태를 관리하는 변수
+
+  // --- Phone Verification State Variables (추가된 부분) ---
+  bool _isVerificationRequested = false; // 인증번호 요청 여부
+  bool _isRequestingVerification = false; // 인증번호를 요청하는 중인지 여부
+  String? _verificationId; // Firebase로부터 받은 인증 ID
+  int _resendCountdown = 0; // 재전송 대기 시간 (초)
+  Timer? _timer; // 카운트다운 타이머
 
   @override
   void dispose() {
+    // 모든 컨트롤러와 타이머를 정리합니다.
     _nameController.dispose();
     _birthdateController.dispose();
     _phoneController.dispose();
     _authCodeController.dispose();
+    _timer?.cancel();
     super.dispose();
   }
 
-  /// '계속하기' 버튼을 눌렀을 때 실행될 메서드
+  /// 전화번호 인증 코드 발송을 요청하는 메서드 (새로 추가된 메서드)
+  Future<void> _requestVerification() async {
+    // 전화번호 유효성 검사
+    final phone = _phoneController.text.trim();
+    if (phone.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('전화번호를 입력해주세요.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _isRequestingVerification = true;
+      _isLoading = true; // 전체적인 로딩 상태
+    });
+
+    // 국가번호(+82)를 포함한 전체 전화번호
+    final fullPhoneNumber = "+82$phone";
+
+    try {
+      await _communityService.verifyPhoneNumber(
+        phoneNumber: fullPhoneNumber,
+        codeSent: (verificationId) {
+          if (mounted) {
+            setState(() {
+              _verificationId = verificationId;
+              _isVerificationRequested = true;
+              _isRequestingVerification = false;
+              _isLoading = false;
+              _resendCountdown = 60; // 60초 타이머 시작
+            });
+            _startCountdown();
+          }
+        },
+        verificationFailed: (error) {
+          if (mounted) {
+            setState(() {
+              _isRequestingVerification = false;
+              _isLoading = false;
+            });
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('인증 실패: $error'),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+      );
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isRequestingVerification = false;
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('인증 코드 요청에 실패했습니다: ${e.toString()}'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  /// 재전송 카운트다운을 시작하는 메서드 (새로 추가된 메서드)
+  void _startCountdown() {
+    _timer?.cancel(); // 기존 타이머가 있다면 취소
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_resendCountdown == 0) {
+        if (mounted) {
+          setState(() {
+            timer.cancel();
+          });
+        }
+      } else {
+        if (mounted) {
+          setState(() {
+            _resendCountdown--;
+          });
+        }
+      }
+    });
+  }
+
+  /// '계속하기' 버튼을 눌렀을 때 실행될 메서드 (수정된 메서드)
   Future<void> _submitProfile() async {
-    // TODO: 폼 유효성 검사 로직 추가 (예: 모든 필드가 채워졌는지)
+    // 1. 폼 유효성 검사
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    // 2. 인증번호 요청 여부 및 인증번호 입력 확인
+    if (_verificationId == null || _authCodeController.text.length != 6) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('휴대폰 인증을 먼저 완료해주세요.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
 
     setState(() {
       _isLoading = true; // 로딩 시작
     });
 
     try {
-      // 국적 문자열 결정
-      final String country = _nationalitySelection[0] ? '내국인' : '외국인';
+      // 3. SMS 인증 코드 검증
+      await _communityService.verifySMSCode(
+        verificationId: _verificationId!,
+        smsCode: _authCodeController.text.trim(),
+      );
 
-      // Firestore에 프로필 정보 저장
+      // 4. 인증 성공 시, 프로필 정보 저장
+      final String country = _nationalitySelection[0] ? '내국인' : '외국인';
       await _communityService.saveProfileInformation(
         name: _nameController.text,
         country: country,
@@ -61,9 +179,16 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
         phoneNumber: "+82${_phoneController.text}", // 국가번호 포함
       );
 
-      // 저장 성공 시 다음 화면으로 이동
+      // 5. 저장 성공 시 다음 화면으로 이동
       if (mounted) {
-        Navigator.push(
+        // 성공 메시지 표시
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('인증 및 프로필 저장이 완료되었습니다!'),
+            backgroundColor: Colors.green,
+          ),
+        );
+        Navigator.pushReplacement( // pushReplacement로 변경하여 뒤로가기 시 이 화면으로 오지 않도록 함
           context,
           MaterialPageRoute(
             builder: (context) => const PolicyAgreementScreen(),
@@ -75,7 +200,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('프로필 저장에 실패했습니다: ${e.toString()}'),
+            content: Text('처리 중 오류가 발생했습니다: ${e.toString()}'),
             backgroundColor: Colors.red,
           ),
         );
@@ -95,38 +220,43 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
     return Scaffold(
       backgroundColor: const Color(0xFFFAFAFA),
       appBar: _buildAppBar(context),
-      body: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const SizedBox(height: 30),
-                    _buildSectionTitle('이름'),
-                    const SizedBox(height: 8),
-                    _buildNameAndNationality(),
-                    const SizedBox(height: 35),
-                    _buildSectionTitle('생년월일'),
-                    const SizedBox(height: 8),
-                    _buildBirthdateAndGender(),
-                    const SizedBox(height: 35),
-                    _buildSectionTitle('휴대폰 인증'),
-                    const SizedBox(height: 15),
-                    _buildPhoneAuthSection(),
-                    const SizedBox(height: 40),
-                  ],
+      body: Form( // Form 위젯으로 감싸 유효성 검사를 활성화합니다.
+        key: _formKey,
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 30),
+                      _buildSectionTitle('이름'),
+                      const SizedBox(height: 8),
+                      _buildNameAndNationality(),
+                      const SizedBox(height: 35),
+                      _buildSectionTitle('생년월일'),
+                      const SizedBox(height: 8),
+                      _buildBirthdateAndGender(),
+                      const SizedBox(height: 35),
+                      _buildSectionTitle('휴대폰 인증'),
+                      const SizedBox(height: 15),
+                      _buildPhoneAuthSection(), // 수정된 휴대폰 인증 섹션
+                      const SizedBox(height: 40),
+                    ],
+                  ),
                 ),
               ),
             ),
-          ),
-          _buildContinueButton(),
-        ],
+            _buildContinueButton(), // 수정된 계속하기 버튼
+          ],
+        ),
       ),
     );
   }
+  
+  // --- 이하 위젯 빌드 메서드들 ---
 
   PreferredSizeWidget _buildAppBar(BuildContext context) {
     return AppBar(
@@ -172,7 +302,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Expanded(
-          child: TextField(
+          child: TextFormField( // TextField -> TextFormField로 변경
             controller: _nameController,
             style: const TextStyle(
               color: Color(0xFF121212),
@@ -181,6 +311,12 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
               fontWeight: FontWeight.w500,
             ),
             decoration: _textFieldDecoration(hintText: '이름'),
+            validator: (value) {
+              if (value == null || value.trim().isEmpty) {
+                return '이름을 입력해주세요.';
+              }
+              return null;
+            },
           ),
         ),
         const SizedBox(width: 15),
@@ -222,7 +358,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Expanded(
-          child: TextField(
+          child: TextFormField( // TextField -> TextFormField로 변경
             controller: _birthdateController,
             style: const TextStyle(
               color: Color(0xFF121212),
@@ -236,6 +372,12 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
               FilteringTextInputFormatter.digitsOnly,
               LengthLimitingTextInputFormatter(6),
             ],
+            validator: (value) {
+              if (value == null || value.length != 6) {
+                return '6자리 생년월일을 입력해주세요.';
+              }
+              return null;
+            },
           ),
         ),
         const SizedBox(width: 25),
@@ -278,8 +420,12 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
       ),
     );
   }
-
+  
+  /// 휴대폰 인증 섹션 UI (수정된 부분)
   Widget _buildPhoneAuthSection() {
+    // 재전송 버튼이 활성화되어야 하는지 여부
+    final canResend = _resendCountdown == 0 && !_isRequestingVerification;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -297,7 +443,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
         Row(
           children: [
             Expanded(
-              child: TextField(
+              child: TextFormField( // TextField -> TextFormField로 변경
                 controller: _phoneController,
                 keyboardType: TextInputType.phone,
                 style: const TextStyle(
@@ -307,7 +453,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
                   fontWeight: FontWeight.w500,
                 ),
                 decoration: _textFieldDecoration(
-                  hintText: '전화번호 입력',
+                  hintText: "'-' 없이 전화번호 입력",
                   prefixText: '+82 ',
                 ).copyWith(
                   border: const OutlineInputBorder(
@@ -325,21 +471,22 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
                     borderSide: BorderSide(color: Color(0xFF5F37CF)),
                   ),
                 ),
+                 validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '전화번호를 입력해주세요.';
+                  }
+                  return null;
+                },
               ),
             ),
             SizedBox(
               width: 116,
               height: 52,
               child: TextButton(
-                onPressed: () {
-                  setState(() {
-                    _isVerificationRequested = true;
-                  });
-                  // TODO: Add phone verification logic here
-                  print('Verification requested for ${_phoneController.text}');
-                },
+                // 카운트다운 중이 아닐 때만 버튼 활성화
+                onPressed: canResend ? _requestVerification : null,
                 style: TextButton.styleFrom(
-                  backgroundColor: const Color(0xFF121212),
+                  backgroundColor: canResend ? const Color(0xFF121212) : Colors.grey,
                   foregroundColor: Colors.white,
                   shape: const RoundedRectangleBorder(
                     borderRadius: BorderRadius.only(
@@ -348,30 +495,43 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
                     ),
                   ),
                 ),
-                child: Text(
-                  _isVerificationRequested ? '재전송' : '인증요청',
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontFamily: 'Pretendard',
-                    fontWeight: FontWeight.w500,
-                  ),
+                child: _isRequestingVerification 
+                  ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2,))
+                  : Text(
+                      _isVerificationRequested ? (_resendCountdown > 0 ? '${_resendCountdown}초' : '재전송') : '인증요청',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w500,
+                      ),
                 ),
               ),
             ),
           ],
         ),
-        const SizedBox(height: 8),
-        TextField(
-          controller: _authCodeController,
-          keyboardType: TextInputType.number,
-          style: const TextStyle(
-            color: Color(0xFF121212),
-            fontSize: 16,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w500,
+        if (_isVerificationRequested) ...[
+          const SizedBox(height: 8),
+          TextFormField( // TextField -> TextFormField로 변경
+            controller: _authCodeController,
+            keyboardType: TextInputType.number,
+            maxLength: 6,
+            style: const TextStyle(
+              color: Color(0xFF121212),
+              fontSize: 16,
+              fontFamily: 'Pretendard',
+              fontWeight: FontWeight.w500,
+            ),
+            decoration: _textFieldDecoration(hintText: '인증번호 6자리 입력').copyWith(
+              counterText: '', // 글자 수 카운터 숨기기
+            ),
+            validator: (value) {
+              if (value == null || value.length != 6) {
+                return '인증번호 6자리를 입력해주세요.';
+              }
+              return null;
+            },
           ),
-          decoration: _textFieldDecoration(hintText: '인증번호 입력'),
-        ),
+        ]
       ],
     );
   }
@@ -422,7 +582,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
     );
   }
 
-  /// 하단의 '계속하기' 버튼 위젯을 빌드합니다. (수정된 부분)
+  /// 하단의 '계속하기' 버튼 위젯 (수정된 부분)
   Widget _buildContinueButton() {
     return SafeArea(
       child: Container(
@@ -437,7 +597,7 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
               backgroundColor: const Color(0xFF5F37CF),
               foregroundColor: const Color(0xFFFAFAFA),
               // 로딩 중일 때 비활성화된 버튼 색상
-              disabledBackgroundColor: Colors.grey,
+              disabledBackgroundColor: const Color(0xFF5F37CF).withOpacity(0.5),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
               ),
@@ -491,6 +651,14 @@ class _ProfileInformationScreenState extends State<ProfileInformationScreen> {
       focusedBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(6),
         borderSide: const BorderSide(color: Color(0xFF5F37CF)),
+      ),
+      errorBorder: OutlineInputBorder( // 에러 발생 시 테두리
+        borderRadius: BorderRadius.circular(6),
+        borderSide: const BorderSide(color: Colors.red, width: 1.0),
+      ),
+      focusedErrorBorder: OutlineInputBorder( // 에러 발생 후 포커스 시 테두리
+        borderRadius: BorderRadius.circular(6),
+        borderSide: const BorderSide(color: Colors.red, width: 2.0),
       ),
     );
   }


### PR DESCRIPTION
다음은 사용자가 제공한 두 개의 markdown 문서를 **중복 항목 제거 및 통합 정리**한 결과입니다. 항목을 기능 구현 중심과 오류 해결 중심으로 나누고, 동일 항목은 병합하였습니다.

---

# 📱 Flutter 앱 기능 구현 및 트러블슈팅 정리

> 사용자의 프로필 정보를 입력받고 Firebase 휴대폰 인증을 연동하는 과정, 그리고 이 과정에서 발생한 주요 오류 및 해결 방법을 정리합니다.

---

## 1. 핵심 기능 구현

### 1.1. 화면: `profile_information_screen.dart`

Flutter를 활용하여 사용자가 **이름, 생년월일, 성별, 통신사, 전화번호, 인증번호**를 입력하고 Firebase 인증을 한 화면에서 처리하도록 구성하였습니다.

#### 🔧 주요 구현 사항

* **인증 로직 통합**: 별도 화면 없이 하나의 스크린 내에서 인증 요청부터 완료까지 절차 처리
* **상태 관리**: `_isLoading`, `_isRequestingVerification`, `_verificationId`, `_resendCountdown`, `_timer` 등 도입
* **동적 UI 변경**: 인증 요청 시 버튼 상태 → 타이머 → 재전송 버튼 전환 / 인증번호 입력 필드는 조건부 렌더링
* **Form 유효성 검사**: `TextFormField`의 `validator`로 입력값 필수 검사 구현

#### 🧭 사용자 플로우

1. 사용자 정보 입력
2. '인증요청' 버튼 → Firebase SMS 요청
3. 인증번호 필드 등장 → 입력
4. '계속하기' 클릭 → 인증코드 검증 → Firestore에 프로필 저장

### 1.2. 서비스 로직: `community_service.dart`

* `verifyPhoneNumber()` : SMS 요청
* `verifySMSCode()` : 인증 완료 처리
* `saveProfileInformation()` : Firestore 저장

---

## 2. 주요 오류 및 해결 방법 (Troubleshooting)

### 🛠 2.1. SHA-1 지문 불일치 오류

**오류 메시지**
`SHA-1 and SHA-256 does not match your app's package name.`

**원인**
Firebase에 등록된 키와 실제 빌드 환경의 SHA-1, SHA-256 지문이 일치하지 않음

**해결방법**

1. `./gradlew signingReport` 명령 실행 후 키 확인
2. Firebase 콘솔 → SHA-1/256 등록
3. `google-services.json` 다시 다운로드
4. `flutter clean` → 앱 재실행
5. ✅ \*\*올바른 프로젝트 폴더 내(`mvp`)\*\*에서 빌드해야 정확한 SHA-1/256 적용

---

### 🚫 2.2. Firebase 인증 요청 차단 오류

**오류 메시지**
`We have blocked all requests from this device due to unusual activity.`

**원인**
짧은 시간 내 반복된 인증 요청으로 인해 Firebase가 스팸으로 인식하여 해당 기기 차단

**해결책**

1. ✅ **테스트용 전화번호 사용** (Firebase Console > Authentication > Phone)

   * 예: `+82 10-1111-1111` / 인증 코드 `111111`
2. 실제 기기 사용 권장 (에뮬레이터는 차단 빈도 높음)
3. (출시 전 대비) **App Check** 및 **Play Integrity API** 적용

---

✅ 위 항목을 기반으로 각각의 개발 Task 혹은 문서 항목으로 사용하셔도 좋습니다.
필요 시 항목별로 리팩터링하거나 표 형태로 제공해드릴 수도 있습니다. 원하시나요?
