### PR TITLE
Feat/community my page

### DIFF
--- a/demo250701/lib/main.dart
+++ b/demo250701/lib/main.dart
@@ -50,7 +50,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
       routes: {
-        '/': (context) =>  SplashScreen(), //CommunityMainScreen(),
+        '/': (context) => CommunityMainScreen(), //SplashScreen(), //CommunityMainScreen(),
         '/login': (context) => const LoginScreen(),
         '/after-login-splash': (context) => const AfterLoginSplashScreen(),
         '/home': (context) => const HomeScreen(),

--- a/demo250701/lib/main.dart
+++ b/demo250701/lib/main.dart
@@ -50,7 +50,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
       routes: {
-        '/': (context) =>  CommunityMainScreen(), //SplashScreen(), //CommunityMainScreen(),
+        '/': (context) =>   SplashScreen(), //CommunityMainScreen(),
         '/login': (context) => const LoginScreen(),
         '/after-login-splash': (context) => const AfterLoginSplashScreen(),
         '/home': (context) => const HomeScreen(),

--- a/demo250701/lib/main.dart
+++ b/demo250701/lib/main.dart
@@ -14,7 +14,7 @@ import 'screens/intro_community_splash.dart'; // Import the new splash screen
 
 // for test 
 import 'screens/community/community_mvp/community_main.dart'; 
-
+import 'screens/community/my_communities_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -50,7 +50,7 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       initialRoute: '/',
       routes: {
-        '/': (context) => CommunityMainScreen(), //SplashScreen(), //CommunityMainScreen(),
+        '/': (context) =>  CommunityMainScreen(), //SplashScreen(), //CommunityMainScreen(),
         '/login': (context) => const LoginScreen(),
         '/after-login-splash': (context) => const AfterLoginSplashScreen(),
         '/home': (context) => const HomeScreen(),

--- a/demo250701/lib/models/post_model.dart
+++ b/demo250701/lib/models/post_model.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Post {
+  final String id; // The property to hold the document ID
   final String postId;
   final String userId; // User who posted
   final String communityId;
@@ -15,6 +16,7 @@ class Post {
   final DateTime updatedAt;
 
   Post({
+    required this.id,
     required this.postId,
     required this.userId,
     required this.communityId,
@@ -50,6 +52,7 @@ class Post {
   // Create Post object from Firestore document
   factory Post.fromMap(Map<String, dynamic> map, String documentId) {
     return Post(
+      id: documentId, // Set the document ID
       postId: documentId,
       userId: map['userId'] ?? '',
       communityId: map['communityId'] ?? '',
@@ -81,6 +84,7 @@ class Post {
     DateTime? updatedAt,
   }) {
     return Post(
+      id: id, // Keep the original document ID
       postId: postId ?? this.postId,
       userId: userId ?? this.userId,
       communityId: communityId ?? this.communityId,

--- a/demo250701/lib/screens/community/community_mvp/community_main.dart
+++ b/demo250701/lib/screens/community/community_mvp/community_main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../services/community_service.dart'; // hot posts, general posts, my posts
 import '../post_detail_screen.dart';
+import '../../../models/post_model.dart';
 
 
 // 커뮤니티 화면을 구성하는 메인 위젯입니다. (StatefulWidget으로 변경)
@@ -18,12 +19,15 @@ class _CommunityMainScreenState extends State<CommunityMainScreen> {
   final CommunityService _communityService = CommunityService();
   // HOT 게시물을 비동기적으로 불러오기 위한 Future 변수
   late Future<List<Map<String, dynamic>>> _hotPostsFuture;
-
+  late Future<List<Post>> _generalPostsFuture; // 종합 게시판 게시물
   @override
   void initState() {
     super.initState();
     // 위젯이 처음 생성될 때 HOT 게시물 데이터를 불러옵니다.
     _hotPostsFuture = _communityService.getHotPosts();
+    // 종합 게시판 게시물 데이터를 불러옵니다.
+    _generalPostsFuture = _communityService.getCommunityPosts('r8zn6yjJtKHP3jyDoJ2x');
+
   }
 
   // PostDetailScreen으로 이동하는 함수 
@@ -64,6 +68,8 @@ class _CommunityMainScreenState extends State<CommunityMainScreen> {
       );
     }
   }
+
+  
 
   @override
   Widget build(BuildContext context) {
@@ -139,15 +145,44 @@ class _CommunityMainScreenState extends State<CommunityMainScreen> {
                 ),
                 const SizedBox(height: 30),
                 // '종합게시판' 섹션
-                _buildBoardSection(
-                  title: '종합게시판',
-                  isGeneral: true,
-                  items: [
-                    '오늘 내가 이런 일이 있었는데 진짜 아닌 것 같다. 내가...',
-                    '오늘 내가 이런 일이 있었는데 진짜 아닌 것 같다. 내가...',
-                    '오늘 내가 이런 일이 있었는데 진짜 아닌 것 같다. 내가...',
-                  ],
-                ),
+// Replace the original '종합게시판' _buildBoardSection with this FutureBuilder
+FutureBuilder<List<Post>>(
+  future: _generalPostsFuture,
+  builder: (context, snapshot) {
+    if (snapshot.connectionState == ConnectionState.waiting) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (snapshot.hasError) {
+      return Center(child: Text('Error: ${snapshot.error}'));
+    }
+    if (!snapshot.hasData || snapshot.data!.isEmpty) {
+      return _buildBoardSection(
+        title: '종합게시판',
+        items: [], // Pass an empty list
+      );
+    }
+
+    // Map the fetched Post data to our _GeneralPostItem widgets
+    final generalPosts = snapshot.data!.map((post) {
+      // Check if the post is new (e.g., posted within the last 24 hours)
+      final bool isNew = DateTime.now().difference(post.datePosted).inHours < 24;
+
+      return _GeneralPostItem(
+        title: post.title,
+        isNew: isNew,
+        postId: post.id,
+        communityId: post.communityId,
+        onTap: () => _navigateToPostDetail(post.id, post.communityId),
+      );
+    }).toList();
+
+    return _buildBoardSection(
+      title: '종합게시판',
+      isGeneral: true,
+      items: generalPosts,
+    );
+  },
+),
                 const SizedBox(height: 30),
                 // '내 게시판' 섹션
                 _buildBoardSection(
@@ -470,8 +505,8 @@ class _CommunityMainScreenState extends State<CommunityMainScreen> {
               // 게시판 종류에 따라 다른 위젯을 렌더링합니다.
               if (title == 'HOT 게시물' && item is _HotPostItem) {
                 itemWidget = item;
-              } else if (isGeneral && item is String) {
-                itemWidget = _GeneralPostItem(title: item, isNew: true);
+              } else if (item is _GeneralPostItem) {
+                itemWidget = item;
               } else if (item is Map<String, String>) {
                  itemWidget = _MyPostItem(category: item['category']!, title: item['title']!, isNew: true);
               } else {
@@ -490,6 +525,7 @@ class _CommunityMainScreenState extends State<CommunityMainScreen> {
     );
   }
 }
+
 
 // 'HOT 게시물' 아이템 위젯
 class _HotPostItem extends StatelessWidget {
@@ -567,26 +603,40 @@ class _HotPostItem extends StatelessWidget {
 class _GeneralPostItem extends StatelessWidget {
   final String title;
   final bool isNew;
+  final String postId;
+  final String communityId;
+  final VoidCallback onTap;
 
-  const _GeneralPostItem({required this.title, this.isNew = false});
+  const _GeneralPostItem({
+    required this.title,
+    this.isNew = false,
+    required this.postId,
+    required this.communityId,
+    required this.onTap,
+  });
+
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(color: Color(0xFF8E8E8E), fontSize: 14),
+    // Wrap with InkWell to make it tappable
+    return InkWell(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Color(0xFF8E8E8E), fontSize: 14),
+            ),
           ),
-        ),
-        if (isNew) ...[
-          const SizedBox(width: 7),
-          _buildNewBadge(),
-        ]
-      ],
+          if (isNew) ...[
+            const SizedBox(width: 7),
+            _buildNewBadge(),
+          ]
+        ],
+      ),
     );
   }
 }
@@ -608,7 +658,7 @@ class _MyPostItem extends StatelessWidget {
             TextSpan(
               children: [
                 TextSpan(
-                  text: '[$category]',
+                  text: '$category',
                   style: const TextStyle(
                     color: Color(0xFF121212),
                     fontSize: 14,

--- a/demo250701/lib/screens/community_screen.dart
+++ b/demo250701/lib/screens/community_screen.dart
@@ -5,6 +5,8 @@ import 'community/category_selection_screen.dart';
 import 'community/add_community_screen.dart';
 import 'community/main_communities_screen.dart';
 import 'community/my_communities_screen.dart';
+// Import design communities UI
+import 'community/community_mvp/community_main.dart'; 
 
 class CommunityScreen extends StatefulWidget {
   const CommunityScreen({super.key});
@@ -207,7 +209,7 @@ class _CommunityScreenState extends State<CommunityScreen> {
                       onPressed: () {
                         Navigator.of(context).push(
                           MaterialPageRoute(
-                            builder: (context) => const MainCommunitiesScreen(),
+                            builder: (context) => CommunityMainScreen(), // const MainCommunitiesScreen(), // 
                           ),
                         );
                       },

--- a/demo250701/lib/services/community_service.dart
+++ b/demo250701/lib/services/community_service.dart
@@ -290,34 +290,42 @@ Future<List<Map<String, dynamic>>> getLatestPostsFromMyCommunities() async {
   if (currentUserId == null) throw 'User not authenticated';
 
   try {
-    // 1. Get all communities the user has joined (1st DB read)
-    final List<Community> myCommunities = await getMyCommunities();
+     final List<Community> myCommunities = await getMyCommunities();
+ 
+
     if (myCommunities.isEmpty) {
       return [];
     }
 
-    // Create a map for quick community name lookups
-    final communityNameMap = {for (var c in myCommunities) c.communityId: c.communityName};
     final communityIds = myCommunities.map((c) => c.communityId).toList();
+ 
 
-    // 2. Fetch all posts from those communities in a single query (2nd DB read)
+
+    if (communityIds.isEmpty) {
+        return [];
+    }
+    
     final postsSnapshot = await _firestore
         .collection('posts')
         .where('communityId', whereIn: communityIds)
         .orderBy('datePosted', descending: true)
         .get();
 
-    // 3. Process the results in memory to find the latest post for each community
+ 
+
+
     final Map<String, Post> latestPostsMap = {};
     for (final doc in postsSnapshot.docs) {
       final post = Post.fromMap(doc.data(), doc.id);
-      // Since the list is sorted by date, the first post we encounter for a community is the latest.
       if (!latestPostsMap.containsKey(post.communityId)) {
         latestPostsMap[post.communityId] = post;
       }
     }
+ 
 
-    // 4. Format the data for the UI
+
+    // ... 이하 코드는 동일 ...
+    final communityNameMap = {for (var c in myCommunities) c.communityId: c.communityName};
     final result = latestPostsMap.entries.map((entry) {
       final communityId = entry.key;
       final post = entry.value;
@@ -330,13 +338,10 @@ Future<List<Map<String, dynamic>>> getLatestPostsFromMyCommunities() async {
       };
     }).toList();
     
-    // Sort the final list by post date to show the absolute newest posts first
     result.sort((a, b) => (b['postDate'] as DateTime).compareTo(a['postDate'] as DateTime));
-
     return result;
     
   } catch (e) {
-    print('Error fetching latest posts from my communities: $e');
     return [];
   }
 }


### PR DESCRIPTION
[community - Main]
# **'종합 게시판' 게시물 표시 기능 구현**

  - **작성일**: 2025년 8월 6일
  - **기능 요약**: 커뮤니티 메인 화면의 '종합게시판' 섹션에, 사전에 지정된 특정 커뮤니티('종합게시판', ID: `r8zn6yjJtKHP3jyDoJ2x`)의 최신 게시글 목록을 표시합니다.

## **1. 기능 목표 (Goal)**

모든 사용자가 공통으로 볼 수 있는 중앙 게시판 역할을 하는 '종합게시판'을 구현하는 것을 목표로 합니다. 이 섹션은 특정 커뮤니티 ID를 고정하여 해당 커뮤니티의 소식만을 보여주는 단일 목적의 게시판입니다.

-----

## **2. 주요 구현 내용 (Implementation)**

### **`community_service.dart` - 데이터 로직 구현**

이 기능을 위해 새로운 함수를 만드는 대신, 기존에 존재하던 `getCommunityPosts(String communityId)` 함수를 재사용하여 효율성을 높였습니다.

  - **함수 재사용**: 특정 커뮤니티 ID를 인자로 받아 해당 커뮤니티의 모든 게시물을 가져오는 `getCommunityPosts` 함수를 그대로 활용했습니다.
  - **데이터 처리**: 함수는 `posts` 컬렉션에서 `communityId`가 일치하는 모든 문서를 찾아 `datePosted`를 기준으로 최신순으로 정렬하여 반환합니다.

<!-- end list -->

```dart
// community_service.dart

// Get all posts for a specific community
Future<List<Post>> getCommunityPosts(String communityId) async {
  try {
    final snapshot = await _firestore
        .collection('posts')
        .where('communityId', isEqualTo: communityId)
        .get();

    // Sort in memory to avoid compound index requirement
    final posts = snapshot.docs.map((doc) {
      return Post.fromMap(doc.data(), doc.id);
    }).toList();

    // Sort by datePosted in descending order (newest first)
    posts.sort((a, b) => b.datePosted.compareTo(a.datePosted));

    return posts;
  } catch (e) {
    throw 'Failed to load community posts: ${e.toString()}';
  }
}
```

### **`community_main.dart` - UI 구현**

`FutureBuilder`를 사용하여 '종합게시판' 데이터를 비동기적으로 화면에 표시합니다.

  - **상태 관리**: `_generalPostsFuture`라는 `Future` 변수를 선언하고, `initState`에서 `getCommunityPosts` 함수를 고정된 커뮤니티 ID (`r8zn6yjJtKHP3jyDoJ2x`)와 함께 호출하여 초기화합니다.
  - **UI 바인딩**: `FutureBuilder`가 `_generalPostsFuture`의 상태를 감지하여 로딩, 에러, 데이터 표시 UI를 적절히 렌더링합니다.
  - **위젯 생성**: 데이터 로딩 성공 시, 반환된 `List<Post>` 데이터를 `_GeneralPostItem` 위젯 리스트로 변환합니다. 24시간 이내에 작성된 게시글에는 'N' 배지를 표시하는 로직도 포함되어 있습니다.

<!-- end list -->

```dart
// community_main.dart

// '종합게시판' 섹션
FutureBuilder<List<Post>>(
  future: _generalPostsFuture,
  builder: (context, snapshot) {
    // 1. 로딩 중 UI
    if (snapshot.connectionState == ConnectionState.waiting) {
      return const Center(child: CircularProgressIndicator());
    }
    // 2. 에러 발생 UI
    if (snapshot.hasError) {
      return Center(child: Text('Error: ${snapshot.error}'));
    }
    // 3. 데이터 없음 UI
    if (!snapshot.hasData || snapshot.data!.isEmpty) {
      return _buildBoardSection(
        title: '종합게시판',
        items: [],
      );
    }

    // 4. 데이터 성공 UI
    final generalPosts = snapshot.data!.map((post) {
      // 24시간 이내 글에 'N' 배지 표시
      final bool isNew = DateTime.now().difference(post.datePosted).inHours < 24;

      return _GeneralPostItem(
        title: post.title,
        isNew: isNew,
        postId: post.id,
        communityId: post.communityId,
        onTap: () => _navigateToPostDetail(post.id, post.communityId),
      );
    }).toList();

    return _buildBoardSection(
      title: '종합게시판',
      isGeneral: true,
      items: generalPosts,
    );
  },
),
```

-----

## **3. 기능의 주요 특징 (Key Characteristics)**

  - **단순성과 재사용성**: '내 게시판' 기능과 달리, 별도의 복잡한 데이터 조합이나 쿼리 최적화 과정이 필요 없었습니다. 기존의 범용 함수(`getCommunityPosts`)를 재사용하여 간단하고 빠르게 구현했습니다.
  - **고정된 데이터 소스**: 이 기능은 동적으로 변하는 사용자 정보가 아닌, 하드코딩된 특정 `communityId`를 데이터 소스로 사용합니다. 따라서 모든 사용자에게 동일한 게시물 목록을 보여주는 공통의 정보 채널 역할을 합니다.



# **'내 구독 커뮤니티' 최신 글 표시 기능 구현 및 리팩토링**

  - **작성일**: 2025년 8월 6일
  - **기능 요약**: 커뮤니티 메인 화면의 '내 게시판' 섹션에 현재 로그인한 사용자가 구독한 모든 커뮤니티의 가장 최신 게시글을 각각 하나씩 표시합니다.

## **1. 기능 목표 (Goal)**

사용자가 여러 커뮤니티에 가입했을 때, 각 커뮤니티의 최신 소식을 한눈에 파악할 수 있도록 '내 게시판' 섹션을 동적으로 구성하는 것을 목표로 합니다. 이를 통해 사용자는 앱에 접속하자마자 자신의 관심사에 맞는 최신 정보를 빠르게 확인할 수 있습니다.

-----

## **2. 주요 구현 내용 (Implementation)**

### **`community_service.dart` - 데이터 로직 구현**

`getLatestPostsFromMyCommunities` 함수를 통해 필요한 모든 데이터를 효율적으로 가져오도록 구현했습니다.

  - **쿼리 최적화**: N+1 쿼리 문제를 피하기 위해, 먼저 사용자가 가입한 모든 커뮤니티 목록을 가져온 뒤(`getMyCommunities`), 해당 커뮤니티 ID들을 사용하여 `posts` 컬렉션에 `whereIn` 조건으로 단 한 번만 쿼리합니다.
  - **데이터 처리**: 가져온 게시물 목록은 최신순으로 정렬되어 있으므로, Dart 코드 내에서 Map을 사용하여 각 커뮤니티 ID별로 가장 첫 번째 게시물(가장 최신 글)만 추려냅니다.
  - **결과 포맷팅**: UI에서 사용하기 쉬운 `List<Map<String, dynamic>>` 형태로 최종 데이터를 가공하여 반환합니다.

<!-- end list -->

```dart
// community_service.dart

Future<List<Map<String, dynamic>>> getLatestPostsFromMyCommunities() async {
  if (currentUserId == null) throw 'User not authenticated';

  try {
    // 1. 사용자가 가입한 모든 커뮤니티 목록을 가져옵니다. (DB Read #1)
    final List<Community> myCommunities = await getMyCommunities();
    if (myCommunities.isEmpty) {
      return [];
    }

    final communityIds = myCommunities.map((c) => c.communityId).toList();

    // 2. 해당 커뮤니티 ID들로 모든 게시물을 한 번에 조회합니다. (DB Read #2)
    final postsSnapshot = await _firestore
        .collection('posts')
        .where('communityId', whereIn: communityIds)
        .orderBy('datePosted', descending: true)
        .get();

    // 3. 각 커뮤니티별 최신 글을 메모리에서 필터링합니다.
    final Map<String, Post> latestPostsMap = {};
    for (final doc in postsSnapshot.docs) {
      final post = Post.fromMap(doc.data(), doc.id);
      if (!latestPostsMap.containsKey(post.communityId)) {
        latestPostsMap[post.communityId] = post;
      }
    }
    
    // 4. UI에 필요한 형태로 데이터를 가공합니다.
    final communityNameMap = {for (var c in myCommunities) c.communityId: c.communityName};
    final result = latestPostsMap.entries.map((entry) {
      final communityId = entry.key;
      final post = entry.value;
      return {
        'communityId': communityId,
        'communityName': communityNameMap[communityId] ?? 'Unknown Community',
        'postId': post.id,
        'postTitle': post.title,
        'postDate': post.datePosted,
      };
    }).toList();
    
    result.sort((a, b) => (b['postDate'] as DateTime).compareTo(a['postDate'] as DateTime));
    return result;
    
  } catch (e) {
    print('Error fetching latest posts from my communities: $e');
    return [];
  }
}
```

### **`community_main.dart` - UI 구현**

`FutureBuilder`를 사용하여 비동기 데이터를 처리하고, 로딩, 에러, 데이터 표시 상태를 관리합니다.

  - **상태 관리**: `_myPostsFuture`라는 `Future` 변수를 선언하고 `initState`에서 `getLatestPostsFromMyCommunities` 함수를 호출하여 초기화합니다.
  - **UI 바인딩**: `FutureBuilder`는 `_myPostsFuture`의 상태 변화를 감지하여 UI를 자동으로 갱신합니다.
  - **위젯 생성**: 데이터 로딩이 성공하면, 반환된 `List`를 `map`을 통해 `_MyPostItem` 위젯 리스트로 변환하여 화면에 표시합니다.

<!-- end list -->

```dart
// community_main.dart

// '내 게시판' 섹션
FutureBuilder<List<Map<String, dynamic>>>(
  future: _myPostsFuture,
  builder: (context, snapshot) {
    // 1. 로딩 중 UI
    if (snapshot.connectionState == ConnectionState.waiting) {
      return const Center(child: CircularProgressIndicator());
    }
    // 2. 에러 발생 UI
    if (snapshot.hasError) {
      return Center(child: Text('게시판을 불러오는 데 실패했습니다: ${snapshot.error}'));
    }
    // 3. 데이터 없음 UI
    if (!snapshot.hasData || snapshot.data!.isEmpty) {
      return _buildBoardSection(
        title: '내 게시판',
        items: [],
      );
    }

    // 4. 데이터 성공 UI
    final myPosts = snapshot.data!.map((postData) {
      final DateTime postDate = postData['postDate'];
      final bool isNew = DateTime.now().difference(postDate).inHours < 24;

      return _MyPostItem(
        category: postData['communityName'],
        title: postData['postTitle'],
        isNew: isNew,
        postId: postData['postId'],
        communityId: postData['communityId'],
        onTap: () => _navigateToPostDetail(postData['postId'], postData['communityId']),
      );
    }).toList();

    return _buildBoardSection(
      title: '내 게시판',
      items: myPosts,
    );
  },
),
```

-----

## **3. 문제 해결 및 리팩토링 과정 (Troubleshooting & Refactoring)**

### **Firestore 색인(Index) 문제 해결**

  - **문제 발생**: `whereIn` 필터와 `orderBy` 정렬을 동시에 사용하는 복합 쿼리로 인해 `[cloud_firestore/failed-precondition] The query requires an index.` 오류가 발생했습니다.
  - **원인**: Firestore는 복합 쿼리를 효율적으로 실행하기 위해 해당 쿼리에 맞는 \*\*복합 색인(Composite Index)\*\*을 요구합니다.
  - **해결 과정**:
    1.  오류 메시지에 포함된 링크를 통해 Firebase 콘솔의 색인 생성 페이지로 이동했습니다.
    2.  필요한 필드(`communityId` 오름차순, `datePosted` 내림차순)가 자동으로 채워진 것을 확인하고 색인을 생성했습니다.
    3.  색인 상태가 '사용 설정됨(Enabled)'으로 변경된 후, 쿼리가 정상적으로 실행되는 것을 확인했습니다.

이 과정은 Firestore 사용 시 흔히 발생하는 문제이며, 쿼리 성능과 색인의 중요성을 이해하는 좋은 경험이었습니다.