### PR TITLE
feat/community_mypage_top5_community_UI구현

### DIFF
--- a/demo250701/lib/main.dart
+++ b/demo250701/lib/main.dart
@@ -18,6 +18,8 @@ import 'screens/community/community_mvp/community_tab.dart';
 import 'screens/community/community_mvp/community_tab_mycom.dart'; 
 
 import 'screens/community/my_communities_screen.dart';
+import 'screens/community/main_communities_screen.dart';
+
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Community Feature (커뮤니티 기능)

본 앱의 커뮤니티 기능은 사용자들이 관심사를 기반으로 소통하고 정보를 공유할 수 있는 공간입니다. Firestore 데이터베이스와 연동하여 실시간으로 데이터를 처리하며, 사용자 경험을 고려한 다양한 UI/UX 요소를 포함하고 있습니다.

### 주요 기능

-   **탭 기반 네비게이션**: **MAIN** 탭과 **MY** 탭으로 구분하여 사용자가 원하는 정보에 쉽게 접근할 수 있도록 구성했습니다.
-   **동적 데이터 로딩**: `FutureBuilder`를 활용하여 Firestore로부터 데이터를 비동기적으로 로딩하고, 로딩 상태, 오류 발생, 데이터 없음 등의 다양한 UI 상태를 사용자에게 명확하게 보여줍니다.
-   **데이터 모델링**: `Community` 및 `Post`와 같은 데이터 모델을 사용하여 Firestore 데이터를 Dart 객체로 변환함으로써, 타입 안정성과 코드의 명확성을 확보했습니다.
-   **서비스 로직 분리**: `CommunityService` 클래스를 통해 Firestore와의 통신 로직을 UI 코드로부터 분리하여 코드의 유지보수성과 재사용성을 높였습니다.

---

### 화면 구성 및 상세 기능

#### 🏛️ MAIN 탭

메인 탭은 모든 사용자를 위한 핵심 콘텐츠를 제공합니다.

-   **실시간 재판소**: 사용자들이 실시간으로 투표에 참여할 수 있는 인터랙티브 콘텐츠 섹션입니다.
-   **HOT 게시물**: 전체 게시물 중 **조회수(viewCount)가 가장 높은 상위 3개**의 인기 게시물을 보여줍니다. 각 게시물은 소속 커뮤니티 이름, 제목, 조회수를 표시합니다.
-   **종합 게시판**: 특정 커뮤니티(예: '종합')의 최신 게시글 목록을 보여줍니다. 24시간 내에 작성된 게시물에는 'N' 아이콘이 표시됩니다.
-   **내 게시판**: **사용자가 가입한 모든 커뮤니티**의 최신 글을 모아서 보여줍니다. 커뮤니티 이름과 게시글 제목이 함께 표시되어 어떤 커뮤니티의 글인지 쉽게 파악할 수 있습니다.



#### 👤 MY 탭

MY 탭은 사용자 맞춤형 콘텐츠를 제공하는 개인화된 공간입니다.

-   **내가 가입한 커뮤니티**:
    -   사용자가 가입한 커뮤니티가 없을 경우, 커뮤니티를 찾아볼 것을 권유하는 안내 메시지와 '커뮤니티 찾아보기' 버튼을 표시합니다.
    -   가입한 커뮤니티가 있을 경우, 각 커뮤니티의 배너 이미지, 이름, 그리고 해당 커뮤니티의 **가장 최신 게시물 제목**을 카드 형태로 보여줍니다.
-   **TOP 5 커뮤니티**:
    -   **전체 커뮤니티 중 멤버 수(memberCount)가 가장 많은 상위 5개**의 커뮤니티를 순위와 함께 보여줍니다.
    -   사용자가 새로운 커뮤니티를 발견하고 참여하도록 유도하는 역할을 합니다. 각 카드에는 순위, 커뮤니티 배너, 이름, 설명, 멤버 수가 표시됩니다.



---

### 기술 스택 및 핵심 로직

-   **Backend**: Firebase Firestore
-   **State Management**: `StatefulWidget`의 `setState` 및 `FutureBuilder`
-   **Asynchronous Programming**: `Future`, `async/await`
-   **Firestore Queries**:
    -   `orderBy('viewCount', descending: true).limit(3)`: HOT 게시물 조회
    -   `orderBy('memberCount', descending: true).limit(5)`: TOP 5 커뮤니티 조회
    -   `where('members', arrayContains: currentUserId)`: 사용자가 가입한 커뮤니티 조회