### PR TITLE
Feat/community explore

### DIFF
--- a/demo250807/lib/screens/community/community_mvp/community_explore_page.dart
+++ b/demo250807/lib/screens/community/community_mvp/community_explore_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:math' as math; // for PageController rotation
 import '../../../models/community_model.dart'; // 커뮤니티 모델을 가져옵니다.
 import '../../../services/community_service.dart'; // 커뮤니티 서비스 (API 호출 등)를 가져옵니다.
-
+import '../../../utils/community_navigation_helper.dart'; // 네비게이션 헬퍼를 가져옵니다.
+import '../community_detail_screen.dart'; // 커뮤니티 상세 페이지를 가져옵니다.
 
 class CommunityExplorePage extends StatefulWidget {
   const CommunityExplorePage({super.key});
@@ -285,117 +286,122 @@ class _TopCommunityCard extends StatelessWidget {
           ),
         ],
       ),
-      child: Row(
-        children: [
-          // 왼쪽 이미지
-          ClipRRect(
-            borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(12 * scale),
-              bottomLeft: Radius.circular(12 * scale),
-            ),
-            child: Image.network(
-              info.communityBanner ?? 'https://placehold.co/159x217/EFEFEF/9E9E9E?text=No+Image',
-              width: 159 * scale,
-              // ⚠️ [수정 1] 이미지 높이를 부모 컨테이너 높이에 맞춥니다.
-              height: 212 * scale,
-              fit: BoxFit.cover,
-              loadingBuilder: (context, child, loadingProgress) {
-                if (loadingProgress == null) return child;
-                return const Center(child: CircularProgressIndicator(color: Color(0xFF5F37CF)));
-              },
-              errorBuilder: (context, error, stackTrace) {
-                return Container(
+      // REFACTOR: 탭 기능을 추가하기 위해 ClipRRect와 InkWell 위젯으로 감싸줍니다.
+      child: ClipRRect(
+        // InkWell의 물결 효과가 둥근 모서리를 벗어나지 않도록 설정합니다.
+        borderRadius: BorderRadius.circular(12 * scale),
+        child: InkWell(
+          // 탭 했을 때의 동작을 정의합니다.
+          onTap: () {
+            // 중앙에서 관리하는 공용 네비게이션 함수를 호출합니다.
+            NavigationHelper.navigateToCommunityDetail(context, info.communityId);
+          },
+          child: Row(
+            children: [
+              // 왼쪽 이미지
+              ClipRRect(
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(12 * scale),
+                  bottomLeft: Radius.circular(12 * scale),
+                ),
+                child: Image.network(
+                  info.communityBanner ?? 'https://placehold.co/159x217/EFEFEF/9E9E9E?text=No+Image',
                   width: 159 * scale,
                   height: 212 * scale,
-                  color: Colors.grey[200],
-                  child: Icon(Icons.broken_image_outlined, color: Colors.grey[400]),
-                );
-              },
-            ),
-          ),
-          // 오른쪽 텍스트 정보
-          Expanded(
-            child: Padding(
-              padding: EdgeInsets.fromLTRB(
-                18.0 * scale, 18.0 * scale, 18.0 * scale, 12.0 * scale // 하단 패딩 약간 조정
+                  fit: BoxFit.cover,
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return const Center(child: CircularProgressIndicator(color: Color(0xFF5F37CF)));
+                  },
+                  errorBuilder: (context, error, stackTrace) {
+                    return Container(
+                      width: 159 * scale,
+                      height: 212 * scale,
+                      color: Colors.grey[200],
+                      child: Icon(Icons.broken_image_outlined, color: Colors.grey[400]),
+                    );
+                  },
+                ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 랭킹 배지
-                  Container(
-                    padding: EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 4 * scale),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFF5F37CF),
-                      borderRadius: BorderRadius.circular(400),
-                    ),
-                    child: Text(
-                      '$rank위',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 14 * scale,
-                        fontFamily: 'Pretendard',
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
+              // 오른쪽 텍스트 정보
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    18.0 * scale, 18.0 * scale, 18.0 * scale, 12.0 * scale
                   ),
-                  SizedBox(height: 14 * scale),
-                  // 커뮤니티 제목
-                  Text(
-                    info.communityName,
-                    style: TextStyle(
-                      color: const Color(0xFF121212),
-                      fontSize: 18 * scale,
-                      fontFamily: 'Pretendard',
-                      fontWeight: FontWeight.w600,
-                      height: 1.33,
-                    ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  SizedBox(height: 8 * scale),
-                  
-                  // ⚠️ [수정 2] Spacer 대신 Flexible 위젯 사용
-                  // Flexible 위젯이 남은 공간을 모두 차지하여 설명 텍스트가 유연하게 표시됩니다.
-                  Flexible(
-                    child: Text(
-                      info.announcement ?? '공지사항이 없습니다.',
-                      style: TextStyle(
-                        color: const Color(0xFF8E8E8E),
-                        fontSize: 14 * scale,
-                        fontFamily: 'Pretendard',
-                        fontWeight: FontWeight.w500,
-                        height: 1.4,
-                      ),
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-
-                  // Spacer를 제거했으므로 하단 여백을 위해 SizedBox 추가
-                  SizedBox(height: 8 * scale),
-
-                  // 멤버 수
-                  Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Icon(Icons.person, color: const Color(0xFF5F37CF), size: 14 * scale),
-                      SizedBox(width: 4 * scale),
-                      Text(
-                        '${info.memberCount}명',
-                        style: TextStyle(
+                      // 랭킹 배지
+                      Container(
+                        padding: EdgeInsets.symmetric(horizontal: 10 * scale, vertical: 4 * scale),
+                        decoration: BoxDecoration(
                           color: const Color(0xFF5F37CF),
-                          fontSize: 12 * scale,
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w500,
+                          borderRadius: BorderRadius.circular(400),
                         ),
+                        child: Text(
+                          '$rank위',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 14 * scale,
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      SizedBox(height: 14 * scale),
+                      // 커뮤니티 제목
+                      Text(
+                        info.communityName,
+                        style: TextStyle(
+                          color: const Color(0xFF121212),
+                          fontSize: 18 * scale,
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w600,
+                          height: 1.33,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      SizedBox(height: 8 * scale),
+                      Flexible(
+                        child: Text(
+                          info.announcement ?? '공지사항이 없습니다.',
+                          style: TextStyle(
+                            color: const Color(0xFF8E8E8E),
+                            fontSize: 14 * scale,
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w500,
+                            height: 1.4,
+                          ),
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      SizedBox(height: 8 * scale),
+                      // 멤버 수
+                      Row(
+                        children: [
+                          Icon(Icons.person, color: const Color(0xFF5F37CF), size: 14 * scale),
+                          SizedBox(width: 4 * scale),
+                          Text(
+                            '${info.memberCount}명',
+                            style: TextStyle(
+                              color: const Color(0xFF5F37CF),
+                              fontSize: 12 * scale,
+                              fontFamily: 'Pretendard',
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                ],
+                ),
               ),
-            ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/demo250807/lib/services/community_service.dart
+++ b/demo250807/lib/services/community_service.dart
@@ -311,6 +311,10 @@ class CommunityService {
     }
   }
 
+  // 
+
+
+
   // Get user's community profile data
   Future<Map<String, dynamic>?> getCommunityProfile() async {
     if (currentUserId == null) return null;
@@ -394,6 +398,29 @@ class CommunityService {
 
     } catch (e) {
       print('Error fetching top 5 communities: $e');
+      return [];
+    }
+  }
+
+  // Get communiteis by ordering (communiter_explore_page.dart)
+  /// [sortBy] 필드 기준으로 정렬합니다. ('memberCount', 'createdAt' 등)
+  /// [descending]이 true이면 내림차순, false이면 오름차순으로 정렬합니다.
+  Future<List<Community>> getCommunities({
+    String sortBy = 'memberCount', // 기본 정렬: 인기순
+    bool descending = true,
+  }) async {
+    try {
+      final snapshot = await _firestore
+          .collection('communities')
+          .orderBy(sortBy, descending: descending)
+          .get();
+
+      return snapshot.docs.map((doc) {
+        return Community.fromMap(doc.data(), doc.id);
+      }).toList();
+    } catch (e) {
+      // 앱이 비정상 종료되지 않도록 에러를 처리하고 빈 리스트를 반환합니다.
+      debugPrint('Error fetching communities: $e');
       return [];
     }
   }

--- a/demo250807/lib/utils/community_navigation_helper.dart
+++ b/demo250807/lib/utils/community_navigation_helper.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import '../services/community_service.dart'; // CommunityService 경로
+import '../models/community_model.dart';   // Community 모델 경로
+import '../screens/community/community_detail_screen.dart'; // 상세 페이지 경로
+
+class NavigationHelper {
+  /// 커뮤니티 ID를 받아 상세 정보 로딩 후 해당 페이지로 이동시키는 공용 함수
+  static Future<void> navigateToCommunityDetail(BuildContext context, String communityId) async {
+    // CommunityService 인스턴스를 생성합니다.
+    final communityService = CommunityService();
+
+    // 로딩 중임을 나타내는 다이얼로그를 표시합니다.
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return const Center(child: CircularProgressIndicator());
+      },
+    );
+
+    try {
+      // 서비스를 통해 커뮤니티 상세 정보를 가져옵니다.
+      final Community community = await communityService.getCommunity(communityId);
+
+      // 현재 context가 유효한 경우에만 Navigator를 사용합니다.
+      if (!context.mounted) return;
+      Navigator.of(context).pop(); // 로딩 다이얼로그 닫기
+
+      // 상세 페이지로 이동합니다.
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => CommunityDetailScreen(
+            community: community,
+          ),
+        ),
+      );
+    } catch (e) {
+      // 현재 context가 유효한 경우에만 Navigator와 ScaffoldMessenger를 사용합니다.
+      if (!context.mounted) return;
+      Navigator.of(context).pop(); // 에러 발생 시에도 로딩 다이얼로그 닫기
+
+      // 에러 메시지를 스낵바로 표시합니다.
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('커뮤니티 정보를 불러오는 데 실패했습니다: ${e.toString()}'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
### 주요 기능 구현 및 리팩토링 내역
🔹 Community Explore Page (community_explore_page.dart)
1. 동적 데이터 로딩으로 전환

TOP 5 커뮤니티 캐러셀: 기존의 하드코딩된 목업(Mock) 데이터를 제거하고, community_service의 getTop5Communities 메소드를 호출하여 실시간 인기 커뮤니티 5개를 Firebase에서 받아오도록 FutureBuilder를 적용했습니다.

전체 커뮤니티 목록: 정적이었던 커뮤니티 목록을 Firebase의 communities 컬렉션에서 직접 데이터를 불러와 표시하도록 리팩토링했습니다.

2. 동적 정렬 기능 구현

3가지 정렬 기준 적용: '인기순', '최신순', '오래된 순' 필터 버튼에 실제 정렬 기능을 연동했습니다.

정렬 로직:

인기순: memberCount 필드를 기준으로 내림차순 정렬합니다.

최신순: createdAt 필드를 기준으로 오름차순 정렬합니다. (요청에 따라 '오래된 순'과 로직 교체)

오래된 순: createdAt 필드를 기준으로 내림차순 정렬합니다. (요청에 따라 '최신순'과 로직 교체)

상태 관리: _activeFilter 상태 변수와 setState를 활용하여, 필터 버튼 클릭 시 서버로부터 정렬된 데이터를 새로 불러오는 _fetchCommunityData 메소드를 구현했습니다.

3. 페이지 이동 기능

카드 탭 기능: TOP 5 캐러셀의 커뮤니티 카드를 탭하면 해당 커뮤니티의 상세 페이지로 이동하는 기능을 InkWell과 Navigator를 통해 구현했습니다.

🔸 중앙 집중식 내비게이션 로직 (navigation_helper.dart)
공용 내비게이션 헬퍼 생성: 여러 화면에서 중복되는 '커뮤니티 상세 페이지 이동' 로직을 NavigationHelper.navigateToCommunityDetail 이라는 static 메소드로 분리했습니다.

기능: 이 헬퍼는 로딩 인디케이터 표시, CommunityService를 통한 데이터 fetching, 페이지 이동, 에러 처리 등 상세 페이지 이동에 필요한 모든 과정을 캡슐화합니다.

적용: community_tab_mycom2.dart와 community_explore_page.dart의 페이지 이동 로직을 모두 이 중앙 헬퍼를 사용하도록 통일하여 코드 중복을 제거하고 유지보수성을 크게 향상시켰습니다.

🔹 백엔드 및 서비스 (community_service.dart)
1. 유연한 데이터 조회 메소드 구현

getCommunities 메소드 추가: 다양한 정렬 요구사항을 하나의 메소드로 처리할 수 있도록 sortBy와 descending 파라미터를 받는 getCommunities 메소드를 구현했습니다. 이는 여러 개의 유사한 조회 메소드를 만드는 것을 방지하고 코드의 유연성을 높입니다.

2. Firestore 인덱스 문제 해결

문제 진단: createdAt 필드 정렬이 동작하지 않는 원인이 Firestore의 색인(Index) 누락임을 진단했습니다.

해결 가이드: 디버그 콘솔에서 인덱스 생성 링크를 확인하고, Firebase 콘솔에서 직접 필요한 단일 필드 인덱스를 생성하는 방법을 안내하여 문제를 해결했습니다.

🔸 데이터 모델 (community_model.dart)
안정적인 데이터 변환: Firestore의 Timestamp 타입을 Flutter에서 사용 가능한 DateTime 타입으로 안정적으로 변환하는 로직(fromMap)이 Community 모델에 포함되어 있음을 확인했습니다.

3. 핵심 아키텍처 개선사항
목업 데이터 제거: 앱의 모든 주요 데이터 소스를 정적 목업 데이터에서 Firebase Firestore를 사용하는 동적/실시간 데이터로 성공적으로 전환했습니다.

관심사의 분리 (Separation of Concerns): UI(Widget), 상태 관리(State), 비즈니스 로직(Service) 간의 역할 분리를 명확히 하여 보다 테스트 및 유지보수가 용이한 구조를 확립했습니다.

코드 재사용성 극대화: NavigationHelper와 getCommunities 서비스 메소드를 통해 중복 코드를 제거하고, 앱 전체에서 일관된 동작을 보장하는 중앙 집중식 로직을 구현했습니다.

4. 파일 구조
lib/screens/community/community_explore_page.dart: 커뮤니티 탐색 및 목록 페이지 UI

lib/screens/community/community_tab_mycom2.dart: '내 커뮤니티' 등 메인 커뮤니티 탭 UI

lib/services/community_service.dart: Firestore 데이터 통신을 담당하는 서비스 클래스

lib/models/community_model.dart: Firestore communities 문서의 데이터 모델

lib/utils/navigation_helper.dart: 앱 전역에서 사용되는 공용 내비게이션 로직

5. 필수 설정
Firebase Firestore 인덱스: communities 컬렉션에 대해 다음 필드의 오름차순 및 내림차순 단일 필드 인덱스가 모두 필요합니다.

memberCount

createdAt